### PR TITLE
リファクタなど

### DIFF
--- a/buttons.css
+++ b/buttons.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Ubuntu');
+
 a.btn_Twitter {
     display: block;
     width: 230px;
@@ -15,21 +16,23 @@ a.btn_Twitter {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Twitter i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#0070be;
+
+a.btn_Twitter i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #0070be;
 }
+
 a.btn_Twitter:hover {
     background: #55acee;
     color: #fff;
 }
-a.btn_Twitter:hover i{
+
+a.btn_Twitter:hover i {
     color: #fff;
 }
-
 
 
 a.btn_GitHub {
@@ -48,21 +51,23 @@ a.btn_GitHub {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_GitHub i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color: #f5f5f5;
+
+a.btn_GitHub i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #f5f5f5;
 }
+
 a.btn_GitHub:hover {
     background: #f5f5f5;
     color: #333;
 }
-a.btn_GitHub:hover i{
+
+a.btn_GitHub:hover i {
     color: #333;
 }
-
 
 
 a.btn_Mastodon {
@@ -82,21 +87,23 @@ a.btn_Mastodon {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Mastodon i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#2b90d9;
+
+a.btn_Mastodon i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #2b90d9;
 }
+
 a.btn_Mastodon:hover {
     background: #d9e1e8;
     color: #2b90d9;
 }
-a.btn_Mastodon:hover i{
+
+a.btn_Mastodon:hover i {
     color: #2b90d9;
 }
-
 
 
 a.btn_Email {
@@ -115,20 +122,23 @@ a.btn_Email {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Email i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#dadada;
+
+a.btn_Email i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #dadada;
 }
+
 a.btn_Email:hover {
     border: 2px solid #B23121;
     border-radius: 3px;
     background: #d44638;
     color: #eeeeee;
 }
-a.btn_Email:hover i{
+
+a.btn_Email:hover i {
     color: #eeeeee;
 }
 
@@ -149,18 +159,21 @@ a.btn_Discord {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Discord i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#7289DA;
+
+a.btn_Discord i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #7289DA;
 }
+
 a.btn_Discord:hover {
     background: #7289da;
     color: #fff;
 }
-a.btn_Discord:hover i{
+
+a.btn_Discord:hover i {
     color: #fff;
 }
 
@@ -181,18 +194,21 @@ a.btn_Blogger {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Blogger i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#f06a35;
+
+a.btn_Blogger i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #f06a35;
 }
+
 a.btn_Blogger:hover {
     background: #f06a35;
     color: #fff;
 }
-a.btn_Blogger:hover i{
+
+a.btn_Blogger:hover i {
     color: #fff;
 }
 
@@ -213,19 +229,20 @@ a.btn_Tumblr {
     margin-left: auto;
     margin-right: auto;
 }
-a.btn_Tumblr i{
-    position:absolute;
-	top:59%;
-	left:10px;
-	margin-top:-0.5em;
-	color:#f7f7f7;
+
+a.btn_Tumblr i {
+    position: absolute;
+    top: 59%;
+    left: 10px;
+    margin-top: -0.5em;
+    color: #f7f7f7;
 }
+
 a.btn_Tumblr:hover {
     background: #34445A;
     color: #f7f7f7;
 }
-a.btn_Tumblr:hover i{
+
+a.btn_Tumblr:hover i {
     color: #f7f7f7;
 }
-
-

--- a/buttons.css
+++ b/buttons.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Ubuntu');
-
 a.btn_Twitter {
     display: block;
     width: 230px;

--- a/buttons.css
+++ b/buttons.css
@@ -1,246 +1,127 @@
-a.btn_Twitter {
-    display: block;
+.btn {
     width: 230px;
+    display: block;
     padding: 0.5em;
     text-align: center;
     text-decoration: none;
     font-family: 'Ubuntu', monospace;
-    color: #55acee;
-    border: 2px solid #55acee;
+    border: 2px solid;
     border-radius: 3px;
     transition: .4s;
     position: relative;
-    margin-top: 20px;
+    margin-top: 10px;
     margin-left: auto;
     margin-right: auto;
 }
 
-a.btn_Twitter i {
+.btn > i {
+    background: transparent !important;
     position: absolute;
     top: 59%;
     left: 10px;
     margin-top: -0.5em;
+}
+
+.btn.twitter {
+    color: #55acee;
+    border-color: #55acee;
+}
+
+.btn.gitHub {
+    color: #f5f5f5;
+    border-color: #f5f5f5;
+}
+
+.btn.mastodon {
+    width: 214px;
+    color: #2b90d9;
+    border-color: #2b90d9;
+
+    padding-right: 24px;
+    text-align: right;
+}
+
+.btn.email {
+    color: #dadada;
+    border-color: #d44638;
+
+    text-align: right;
+}
+
+.btn.discord {
+    color: #99aab5;
+    border-color: #7289DA;
+}
+
+.btn.blogger {
+    color: #f06a35;
+    border-color: #f06a35;
+}
+
+.btn.tumblr {
+    color: #f7f7f7;
+    border-color: #34445A;
+}
+
+.btn.twitter i {
     color: #0070be;
 }
 
-a.btn_Twitter:hover {
+.btn.gitHub i {
+    color: #f5f5f5;
+}
+
+.btn.mastodon i {
+    color: #2b90d9;
+}
+
+.btn.email i {
+    color: #dadada;
+}
+
+.btn.discord i {
+    color: #7289DA;
+}
+
+.btn.blogger i {
+    color: #f06a35;
+}
+
+.btn.tumblr i {
+    color: #f7f7f7;
+}
+
+.btn.twitter:hover, .btn.twitter:hover > i {
     background: #55acee;
     color: #fff;
 }
 
-a.btn_Twitter:hover i {
-    color: #fff;
-}
-
-
-a.btn_GitHub {
-    display: block;
-    width: 230px;
-    padding: 0.5em;
-    text-align: center;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #f5f5f5;
-    border: 2px solid #f5f5f5;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_GitHub i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #f5f5f5;
-}
-
-a.btn_GitHub:hover {
+.btn.gitHub:hover, .btn.gitHub:hover > i {
     background: #f5f5f5;
     color: #333;
 }
 
-a.btn_GitHub:hover i {
-    color: #333;
-}
-
-
-a.btn_Mastodon {
-    display: block;
-    width: 214px;
-    padding: 0.5em;
-    padding-right: 24px;
-    text-align: right;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #2b90d9;
-    border: 2px solid #2b90d9;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_Mastodon i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #2b90d9;
-}
-
-a.btn_Mastodon:hover {
+.btn.mastodon:hover, .btn.mastodon:hover > i {
     background: #d9e1e8;
     color: #2b90d9;
 }
 
-a.btn_Mastodon:hover i {
-    color: #2b90d9;
-}
-
-
-a.btn_Email {
-    display: block;
-    width: 230px;
-    padding: 0.5em;
-    text-align: right;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #dadada;
-    border: 2px solid #d44638;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_Email i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #dadada;
-}
-
-a.btn_Email:hover {
-    border: 2px solid #B23121;
-    border-radius: 3px;
+.btn.email:hover, .btn.email:hover > i {
     background: #d44638;
     color: #eeeeee;
 }
 
-a.btn_Email:hover i {
-    color: #eeeeee;
-}
-
-
-a.btn_Discord {
-    display: block;
-    width: 230px;
-    padding: 0.5em;
-    text-align: center;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #99aab5;
-    border: 2px solid #7289DA;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_Discord i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #7289DA;
-}
-
-a.btn_Discord:hover {
+.btn.discord:hover, .btn.discord:hover > i {
     background: #7289da;
     color: #fff;
 }
 
-a.btn_Discord:hover i {
-    color: #fff;
-}
-
-
-a.btn_Blogger {
-    display: block;
-    width: 230px;
-    padding: 0.5em;
-    text-align: center;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #f06a35;
-    border: 2px solid #f06a35;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_Blogger i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #f06a35;
-}
-
-a.btn_Blogger:hover {
+.btn.blogger:hover, .btn.blogger:hover > i {
     background: #f06a35;
     color: #fff;
 }
 
-a.btn_Blogger:hover i {
-    color: #fff;
-}
-
-
-a.btn_Tumblr {
-    display: block;
-    width: 230px;
-    padding: 0.5em;
-    text-align: center;
-    text-decoration: none;
-    font-family: 'Ubuntu', monospace;
-    color: #f7f7f7;
-    border: 2px solid #34445A;
-    border-radius: 3px;
-    transition: .4s;
-    position: relative;
-    margin-top: 10px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-a.btn_Tumblr i {
-    position: absolute;
-    top: 59%;
-    left: 10px;
-    margin-top: -0.5em;
-    color: #f7f7f7;
-}
-
-a.btn_Tumblr:hover {
+.btn.tumblr:hover, .btn.tumblr:hover > i {
     background: #34445A;
-    color: #f7f7f7;
-}
-
-a.btn_Tumblr:hover i {
     color: #f7f7f7;
 }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <meta property="og:description" content="広く浅くオタクな日本の高校生がノリで作った個人サイト" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@yukiyalien" />
-    <meta name="msapplication-TileImage" content="mstile-144x144.png" />
     <meta name="description" content="ももつきゆきや――広く浅くオタクな日本の高校生">
     <title>ももつきゆきや</title>
     <link rel="icon" href="/favicon.ico">

--- a/index.html
+++ b/index.html
@@ -21,22 +21,26 @@
     <title>ももつきゆきや</title>
 </head>
 <body>
-<img class="avatar" src="https://github.com/yukiyalien.png" alt="yukiyalien">
-<h1>ももつきゆきや<br></h1>
-<span class="englishname">Yukiya Momotsuki<br></span>
-<span class="altname">a.k.a. Yukiya, yukiyalien<br></span>
-<p class="aboutme">広く浅くオタクな日本の高校生
+<img class="avatar" src="https://github.com/yukiyalien.png" alt="yukiyalien"/>
+<h1 class="font-notosansjp">ももつきゆきや</h1>
+<div class="englishname font-ubuntu">Yukiya Momotsuki<br></div>
+<div class="altname font-ubuntu text-primary">a.k.a. Yukiya, yukiyalien<br></div>
+<p class="aboutme text-primary font-notosansjp">広く浅くオタクな日本の高校生</p>
 
 <div>
-    <a href="https://twitter.com/yukiyalien" class="btn_Twitter" target="_blank"><i class="fab fa-twitter fa-fw fa-lg"></i>@yukiyalien</a>
-    <a href="https://github.com/yukiyalien" class="btn_GitHub" target="_blank"><i class="fab fa-github fa-fw fa-lg"></i>@yukiyalien</a>
-    <a href="https://friends.nico/@Yukiya" class="btn_Mastodon" target="_blank" rel="me"><i class="fab fa-mastodon fa-fw fa-lg"></i>@Yukiya@friends.nico</a>
-    <a href="mailto:030215yukiya@gmail.com" class="btn_Email" target="_blank"><i class="far fa-envelope fa-fw fa-lg"></i>030215yukiya@gmail.com</a>
-    <a href="https://discordapp.com/users/391589690119028736" class="btn_Discord" target="_blank"><i class="fab fa-discord fa-fw fa-lg"></i>yukiyalien#7365</a>
-    <a href="https://blog.yukiya.me" class="btn_Blogger" target="_blank"><i class="fab fa-blogger fa-fw fa-lg"></i>BLOG.yukiya.me</a>
-    <a href="https://tumblr.yukiya.me" class="btn_Tumblr" target="_blank"><i class="fab fa-tumblr fa-fw fa-lg"></i>Tumblr.yukiya.me</a>
+    <a href="https://twitter.com/yukiyalien" class="btn twitter" target="_blank"><i class="fab fa-twitter fa-fw fa-lg"></i>@yukiyalien</a>
+    <a href="https://github.com/yukiyalien" class="btn gitHub" target="_blank"><i class="fab fa-github fa-fw fa-lg"></i>@yukiyalien</a>
+    <a href="https://friends.nico/@Yukiya" class="btn mastodon" target="_blank" rel="me"><i class="fab fa-mastodon fa-fw fa-lg"></i>@Yukiya@friends.nico</a>
+    <a href="mailto:030215yukiya@gmail.com" class="btn email" target="_blank"><i class="far fa-envelope fa-fw fa-lg"></i>030215yukiya@gmail.com</a>
+    <a href="https://discordapp.com/users/391589690119028736" class="btn discord" target="_blank"><i class="fab fa-discord fa-fw fa-lg"></i>yukiyalien#7365</a>
+    <a href="https://blog.yukiya.me" class="btn blogger" target="_blank"><i class="fab fa-blogger fa-fw fa-lg"></i>BLOG.yukiya.me</a>
+    <a href="https://tumblr.yukiya.me" class="btn tumblr" target="_blank"><i class="fab fa-tumblr fa-fw fa-lg"></i>Tumblr.yukiya.me</a>
 </div>
-<p class="old_and_src"><a href="https://yukiya.me/old" class="old_and_src" target="_blank">Old Page</a>・<a href="https://github.com/yukiyalien/yukiyalien.github.io" class="old_and_src" target="_blank">Source Codes</a></p>
-<p class="copyright">&copy;2019 Yukiya Momotsuki.</p>
+
+<p class="old_and_src font-ubuntu">
+    <a href="https://yukiya.me/old" target="_blank">Old Page</a>・<a href="https://github.com/yukiyalien/yukiyalien.github.io" target="_blank">Source Codes</a>
+</p>
+
+<p class="copyright font-ubuntu text-primary">&copy;2019 Yukiya Momotsuki.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="icon" href="/favicon.ico">
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP|Ubuntu" rel="stylesheet">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
+    <link href="buttons.css" rel="stylesheet" type="text/css">
+    <link href="style.css" rel="stylesheet" type="text/css">
+
     <meta property="og:url" content="https://yukiya.me" />
     <meta property="og:title" content="ももつきゆきや" />
     <meta property="og:type" content="website">
@@ -11,21 +17,17 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@yukiyalien" />
     <meta name="description" content="ももつきゆきや――広く浅くオタクな日本の高校生">
+
     <title>ももつきゆきや</title>
-    <link rel="icon" href="/favicon.ico">
-    <link href="https://fonts.googleapis.com/css?family=Noto+Sans+JP|Ubuntu" rel="stylesheet">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr" crossorigin="anonymous">
-    <link href="buttons.css" rel="stylesheet" type="text/css">
-    <link href="style.css" rel="stylesheet" type="text/css">
 </head>
 <body>
-    <img class="avatar" src="https://github.com/yukiyalien.png" alt="yukiyalien">
-    <h1>ももつきゆきや<br></h1>
-    <span class="englishname">Yukiya Momotsuki<br></span>
-    <span class="altname">a.k.a. Yukiya, yukiyalien<br></span>
-    <p class="aboutme">広く浅くオタクな日本の高校生
+<img class="avatar" src="https://github.com/yukiyalien.png" alt="yukiyalien">
+<h1>ももつきゆきや<br></h1>
+<span class="englishname">Yukiya Momotsuki<br></span>
+<span class="altname">a.k.a. Yukiya, yukiyalien<br></span>
+<p class="aboutme">広く浅くオタクな日本の高校生
 
-    <div>
+<div>
     <a href="https://twitter.com/yukiyalien" class="btn_Twitter" target="_blank"><i class="fab fa-twitter fa-fw fa-lg"></i>@yukiyalien</a>
     <a href="https://github.com/yukiyalien" class="btn_GitHub" target="_blank"><i class="fab fa-github fa-fw fa-lg"></i>@yukiyalien</a>
     <a href="https://friends.nico/@Yukiya" class="btn_Mastodon" target="_blank" rel="me"><i class="fab fa-mastodon fa-fw fa-lg"></i>@Yukiya@friends.nico</a>
@@ -33,8 +35,8 @@
     <a href="https://discordapp.com/users/391589690119028736" class="btn_Discord" target="_blank"><i class="fab fa-discord fa-fw fa-lg"></i>yukiyalien#7365</a>
     <a href="https://blog.yukiya.me" class="btn_Blogger" target="_blank"><i class="fab fa-blogger fa-fw fa-lg"></i>BLOG.yukiya.me</a>
     <a href="https://tumblr.yukiya.me" class="btn_Tumblr" target="_blank"><i class="fab fa-tumblr fa-fw fa-lg"></i>Tumblr.yukiya.me</a>
-    </div>
-    <p class="old_and_src"><a href="https://yukiya.me/old" class="old_and_src" target="_blank">Old Page</a>・<a href="https://github.com/yukiyalien/yukiyalien.github.io" class="old_and_src" target="_blank">Source Codes</a></p>
-    <p class="copyright">&copy;2019 Yukiya Momotsuki.</p>
+</div>
+<p class="old_and_src"><a href="https://yukiya.me/old" class="old_and_src" target="_blank">Old Page</a>・<a href="https://github.com/yukiyalien/yukiyalien.github.io" class="old_and_src" target="_blank">Source Codes</a></p>
+<p class="copyright">&copy;2019 Yukiya Momotsuki.</p>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -13,32 +13,37 @@ img.avatar {
 
 h1 {
     margin-top: 10px;
-    margin-bottom: 0px;
-    font-family: 'Noto Sans JP', sans-serif;
+    margin-bottom: 0;
     color: #ffffff;
+}
+
+.font-ubuntu {
+    font-family: 'Ubuntu', sans-serif;
+}
+
+.font-notosansjp {
+    font-family: 'Noto Sans JP', sans-serif;
+}
+
+.text-primary {
+    color: #9baec8;
 }
 
 .englishname {
     font-size: 22px;
-    font-family: 'Ubuntu', sans-serif;
     color: #d9e1e8;
     margin-bottom: 10px;
 }
 
 .altname {
     font-size: 15px;
-    font-family: 'Ubuntu', sans-serif;
-    color: #9baec8;
 }
 
 .aboutme {
     font-size: 17px;
-    font-family: 'Noto Sans JP', sans-serif;
-    color: #9baec8;
 }
 
-p.old_and_src {
-    font-family: 'Ubuntu', sans-serif;
+.old_and_src, .old_and_src > a {
     color: #9baec8;
     margin-top: 20px;
     margin-bottom: 3px;
@@ -46,15 +51,9 @@ p.old_and_src {
 
 a.old_and_src {
     text-decoration: underline;
-    font-family: 'Ubuntu', sans-serif;
-    color: #9baec8;
-    margin-top: 20px;
-    margin-bottom: 3px;
 }
 
 .copyright {
-    font-family: 'Ubuntu', sans-serif;
-    color: #9baec8;
-    margin-top: 0px;
+    margin-top: 0;
     margin-bottom: 10px;
 }

--- a/style.css
+++ b/style.css
@@ -1,45 +1,50 @@
-body{
-    background-color:#282c37;
+body {
+    background-color: #282c37;
     text-align: center;
 }
+
 img.avatar {
     border: solid 5px #2b90d9;
     border-radius: 50%;
-    width:  180px;
+    width: 180px;
     height: 180px;
     margin-top: 5%;
 }
-h1{
+
+h1 {
     margin-top: 10px;
     margin-bottom: 0px;
     font-family: 'Noto Sans JP', sans-serif;
     color: #ffffff;
 }
-.englishname{
+
+.englishname {
     font-size: 22px;
     font-family: 'Ubuntu', sans-serif;
     color: #d9e1e8;
     margin-bottom: 10px;
 }
-.altname{
+
+.altname {
     font-size: 15px;
     font-family: 'Ubuntu', sans-serif;
     color: #9baec8;
 }
-.aboutme{
+
+.aboutme {
     font-size: 17px;
     font-family: 'Noto Sans JP', sans-serif;
     color: #9baec8;
 }
 
-p.old_and_src{
+p.old_and_src {
     font-family: 'Ubuntu', sans-serif;
     color: #9baec8;
     margin-top: 20px;
     margin-bottom: 3px;
 }
 
-a.old_and_src{
+a.old_and_src {
     text-decoration: underline;
     font-family: 'Ubuntu', sans-serif;
     color: #9baec8;
@@ -47,7 +52,7 @@ a.old_and_src{
     margin-bottom: 3px;
 }
 
-.copyright{
+.copyright {
     font-family: 'Ubuntu', sans-serif;
     color: #9baec8;
     margin-top: 0px;


### PR DESCRIPTION
> 一応元のデザインのまま綺麗にできるコードはしたけどなんか変わっちゃったらすまん

一応勉強のためにも行った変更について大雑把に説明させて頂きます。
- cssはclassで同じ部分を共通化する事ができます。( [buttons.css#L1-L23](https://github.com/yukiyalien/yukiyalien.github.io/blob/c2804ed0a74eab9e7b2800deb9ff93d3943c4fe8/buttons.css#L1-L23), [style.css#L20-L30](https://github.com/yuzulabo/yukiyalien.github.io/blob/c2804ed0a74eab9e7b2800deb9ff93d3943c4fe8/style.css#L20-L30)など ) なるべく共通化しておいた方が後から変更したくなった時にまとめて変更できるから便利ですし、コード量も短くなります。
> なお、共通化させるけど1つや2つだけ値を変えたい、という時は今まで通り個別で書いてしまえば上書きされます。( [buttons.css#L36](https://github.com/yukiyalien/yukiyalien.github.io/blob/c2804ed0a74eab9e7b2800deb9ff93d3943c4fe8/buttons.css#L36)など )
- buttons.cssにあった `@import url('https://fonts.googleapis.com/css?family=Ubuntu');`は既にhtmlのlinkで読み込まれていた為削除しました。
- 多分、style.cssにあった`a.old_and_src`はaタグの装飾が上手くいかなかったから追加したのだと思いますが、そういった時は範囲指定で必ず`a`まで届くようにしてあげるといいと思います。([style.css#L46](https://github.com/yuzulabo/yukiyalien.github.io/blob/c2804ed0a74eab9e7b2800deb9ff93d3943c4fe8/style.css#L46))
- 見出しタグ(`<h1>`)に改行タグを入れるのはあまりよくないかも知れません。見出しタグなどは[ブロック要素](https://developer.mozilla.org/ja/docs/Web/HTML/Block-level_elements)なので自動で改行されます。(ただ絶対ダメという訳でもなく単にコードに違和感があるってだけですが...)
- cssで`0px`など、ゼロを指定する場合は、`0`と書いてしまって大丈夫です。([style.css#L16](https://github.com/yuzulabo/yukiyalien.github.io/blob/c2804ed0a74eab9e7b2800deb9ff93d3943c4fe8/style.css#L16)など)
- metaタグ`msapplication-TileImage`は　`mstile-144x144.png` が存在しないので削除しました。

このくらいかな...?私もプロでは無いのでこれが模範解答という訳ではありませんので参考程度にお願いします。